### PR TITLE
Add a scope option to share a store between sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # storex
 
+## Unreleased
+
+- Stores can now be shared between sessions. `use Storex.Store, scope: :global` puts every session on the node on one process and one state; `use Storex.Store, scope: {:key, "room"}` does the same per value of a join param. The default is `scope: :session`, which is the behaviour Storex has always had, and stores that do not pass the option are unaffected. Under a shared scope `init/2` runs once for the first session to attach, `mutation/5` receives the session that *issued* the mutation rather than the one `init/2` ran with, `terminate/3` runs when the last session detaches, and a mutation's diff is computed once and pushed to every other attached session
+- `Storex.PG` now dispatches a `Storex.mutate/3` or `Storex.mutate/4` broadcast once per store *process* instead of once per registry row. Without that a shared store would run the mutation once per attached session against the state they all share. Nothing changes for `:session` scoped stores, where every row already has a process of its own
+
 ## 0.7.0
 
 - **[BREAKING]** Updated the minimum required version of Elixir to `1.16`

--- a/README.md
+++ b/README.md
@@ -117,6 +117,64 @@ defmodule ExampleApp.Store.Counter do
 end
 ```
 
+### Store scope
+
+By default every connected session gets its own store process and its own
+state. A store's *scope* changes that:
+
+```elixir
+use Storex.Store                          # same as scope: :session
+use Storex.Store, scope: :session         # one process per connected session
+use Storex.Store, scope: :global          # one process for the whole node
+use Storex.Store, scope: {:key, "room"}   # one process per params["room"] value
+```
+
+With `:global` or `{:key, _}` several sessions share one process and one state.
+A mutation is applied once, the diff is computed once, and it reaches every
+session attached to that process — the session that issued the mutation gets it
+as the reply to its own `commit`, the rest receive it as a push and their
+`subscribe` listeners fire.
+
+```elixir
+defmodule ExampleApp.Store.Chat do
+  use Storex.Store, scope: {:key, "room"}
+
+  def init(_session_id, params) do
+    {:ok, %{room: Map.fetch!(params, "room"), messages: []}}
+  end
+
+  # `session_id` is the session that issued the mutation, so a shared store can
+  # tell its clients apart.
+  def mutation("send", [text], session_id, _params, state) do
+    {:noreply, %{state | messages: state.messages ++ [%{from: session_id, text: text}]}}
+  end
+end
+```
+
+```typescript
+const chat = useStorex({ store: 'ExampleApp.Store.Chat', params: { room: 'lobby' } })
+
+chat.subscribe((state) => render(state.messages))
+chat.commit('send', 'hello')   // every session in `lobby` sees it
+```
+
+What a shared scope changes about the callbacks:
+
+- `init/2` runs **once**, when the first session attaches. It gets that
+  session's id and params; the params of every session that attaches later are
+  ignored.
+- `mutation/5` gets the id of the session that *issued* the mutation. Its
+  `params` argument is always the ones `init/2` ran with.
+- `terminate/3` runs when the **last** session detaches, with the session id
+  and params `init/2` was given.
+- A store scoped by `{:key, name}` refuses to join when the param is missing,
+  with an error frame rather than a dropped connection.
+
+`:global` is per node, not per cluster. `Storex.mutate/3` and `Storex.mutate/4`
+broadcast to every node, so a `:global` store receives a mutation once per node,
+against that node's own copy of the state.
+
+
 ### Connect to store
 
 You have to connect the newly created store with a frontend side to be able to synchronise the state: `params` are passed as second argument in store `init/2` and as third in `mutation/5`. You can subscribe to changes inside store state by passing option `subscribe` with function as a value.

--- a/lib/storex/handler/cowboy.ex
+++ b/lib/storex/handler/cowboy.ex
@@ -56,6 +56,11 @@ defmodule Storex.Handler.Cowboy do
     |> map_response()
   end
 
+  def websocket_info({:storex_diff, store, diff}, state) do
+    Socket.diff_handle(store, diff, state)
+    |> map_response()
+  end
+
   def websocket_info(_info, state) do
     {:ok, state}
   end

--- a/lib/storex/handler/plug.ex
+++ b/lib/storex/handler/plug.ex
@@ -54,6 +54,11 @@ defmodule Storex.Handler.Plug do
     |> map_response()
   end
 
+  def handle_info({:storex_diff, store, diff}, state) do
+    Socket.diff_handle(store, diff, state)
+    |> map_response()
+  end
+
   def handle_info(_info, state) do
     {:ok, state}
   end

--- a/lib/storex/pg.ex
+++ b/lib/storex/pg.ex
@@ -28,9 +28,7 @@ defmodule Storex.PG do
   @impl true
   def handle_info({:broadcast, {:mutate, store, mutation, payload}}, state) do
     Storex.Registry.get_store_instances({store, :_, :_, :_, :_})
-    |> Enum.map(fn {^store, _, _, session_pid, _} ->
-      Kernel.send(session_pid, {:mutate, store, mutation, payload})
-    end)
+    |> dispatch(store, mutation, payload)
 
     {:noreply, state}
   end
@@ -38,9 +36,7 @@ defmodule Storex.PG do
   @impl true
   def handle_info({:broadcast, {:mutate, key, store, mutation, payload}}, state) do
     Storex.Registry.get_store_instances({store, :_, :_, :_, key})
-    |> Enum.each(fn {^store, _, _, session_pid, ^key} ->
-      Kernel.send(session_pid, {:mutate, store, mutation, payload})
-    end)
+    |> dispatch(store, mutation, payload)
 
     {:noreply, state}
   end
@@ -48,5 +44,18 @@ defmodule Storex.PG do
   @impl true
   def handle_info(_, state) do
     {:noreply, state}
+  end
+
+  # One message per store *process*, not per registry row. Under a shared scope
+  # many sessions resolve to the same process, and the mutation has to run once
+  # against the state they share — the diff then reaches the other sessions on
+  # its own. Under the default `:session` scope every row already has a process
+  # of its own, so nothing is deduplicated away.
+  defp dispatch(rows, store, mutation, payload) do
+    rows
+    |> Enum.uniq_by(fn {_store, store_pid, _session, _session_pid, _key} -> store_pid end)
+    |> Enum.each(fn {_store, _store_pid, _session, session_pid, _key} ->
+      Kernel.send(session_pid, {:mutate, store, mutation, payload})
+    end)
   end
 end

--- a/lib/storex/registry.ex
+++ b/lib/storex/registry.ex
@@ -54,6 +54,15 @@ defmodule Storex.Registry do
     :ets.match_object(@registry, {:_, :_, session, :_, :_})
   end
 
+  # Every session attached to one store process, as `{session, session_pid}`.
+  # Under the default `:session` scope that is always a single row; under a
+  # shared scope it is the fan-out list for a diff, and the reference count that
+  # decides when the process stops.
+  def store_sessions(store_pid) do
+    :ets.match(@registry, {:_, store_pid, :"$1", :"$2", :_})
+    |> Enum.map(fn [session, session_pid] -> {session, session_pid} end)
+  end
+
   def handle_call({:register_store, store, store_pid, session, session_pid, key}, _from, state) do
     :ets.insert(@registry, {store, store_pid, session, session_pid, key})
     Process.monitor(store_pid)

--- a/lib/storex/socket.ex
+++ b/lib/storex/socket.ex
@@ -7,6 +7,22 @@ defmodule Storex.Socket do
     - `4001`: Store is not defined or can't be compiled.
   """
 
+  # A diff produced by somebody else's mutation on a store this session shares.
+  # It carries no `request`, because this session did not ask for it — the
+  # client applies the diff and resolves nothing.
+  @doc false
+  def diff_handle(store, diff, %{session: session} = state) do
+    %{
+      type: "mutation",
+      session: session,
+      store: store,
+      diff: diff,
+      request: nil
+    }
+    |> Jason.encode!()
+    |> (&{:text, &1, state}).()
+  end
+
   @doc false
   def message_handle(%{type: "ping"} = message, state) do
     message =

--- a/lib/storex/store.ex
+++ b/lib/storex/store.ex
@@ -1,4 +1,43 @@
 defmodule Storex.Store do
+  @moduledoc """
+  Behaviour for a Storex store.
+
+  ## Scope
+
+  A store's *scope* decides how many processes — and therefore how many
+  independent states — exist for a given store module. It is set on `use`:
+
+  ```elixir
+  use Storex.Store                          # same as scope: :session
+  use Storex.Store, scope: :session         # one process per connected session
+  use Storex.Store, scope: :global          # one process for the whole node
+  use Storex.Store, scope: {:key, "room"}   # one process per params["room"] value
+  ```
+
+  With the default `:session` scope every connection gets its own store process
+  and its own state, which is the behaviour Storex has always had.
+
+  With `:global` or `{:key, _}` several sessions share one process and one
+  state. A mutation is applied once, the diff is computed once, and it is sent
+  to every session attached to that process — the one that issued the mutation
+  gets it as the reply to its own request, the rest receive it as a push.
+
+  Shared scopes change what the callbacks are handed:
+
+  - `init/2` runs **once**, when the first session attaches. It receives that
+    session's id and params; the params of every session that attaches later are
+    ignored.
+  - `mutation/5` receives the id of the session that *issued* the mutation, so a
+    shared store can tell its clients apart. The `params` argument is always the
+    ones `init/2` ran with.
+  - `terminate/3` runs when the **last** session detaches, with the session id
+    `init/2` was given.
+
+  `:global` is per node, not per cluster. `Storex.mutate/3` and `Storex.mutate/4`
+  broadcast to every node, so a `:global` store still receives a mutation once
+  per node, against that node's own copy of the state.
+  """
+
   @doc """
   Called when store session starts.
   """
@@ -52,6 +91,52 @@ defmodule Storex.Store do
     __MODULE__ in (module.module_info(:attributes)
                    |> Keyword.get_values(:behaviour)
                    |> List.flatten())
+  end
+
+  @doc false
+  # The identity a store process is registered under. Everything that shares a
+  # scope id shares a process, and therefore a state. For the default `:session`
+  # scope the id is the session itself, which is why nothing changes for stores
+  # that do not opt in.
+  def scope_id(module, session, params) do
+    scope_id(scope(module), module, session, params)
+  end
+
+  defp scope_id(:session, _module, session, _params), do: {:ok, session}
+
+  defp scope_id(:global, _module, _session, _params), do: {:ok, :global}
+
+  defp scope_id({:key, key}, _module, _session, params) when is_map_key(params, key) do
+    {:ok, {key, Map.fetch!(params, key)}}
+  end
+
+  defp scope_id({:key, key}, module, _session, _params) do
+    {:error, "Store #{inspect(module)} is scoped by param #{inspect(key)}, which was not given."}
+  end
+
+  @doc false
+  # `function_exported?/3` answers `false` for a module that is not loaded yet,
+  # so asking it alone silently degrades every store to `:session` scope
+  # depending on what the code server happens to hold — the same trap
+  # `__terminate__/4` fell into. The fallback is for a module that declares the
+  # behaviour by hand instead of through `use Storex.Store`, and so has no
+  # `__storex_scope__/0` at all.
+  def scope(module) do
+    if Code.ensure_loaded?(module) and function_exported?(module, :__storex_scope__, 0) do
+      module.__storex_scope__()
+    else
+      :session
+    end
+  end
+
+  @doc false
+  def __validate_scope__(:session), do: :session
+  def __validate_scope__(:global), do: :global
+  def __validate_scope__({:key, key} = scope) when is_binary(key), do: scope
+
+  def __validate_scope__(other) do
+    raise ArgumentError,
+          "invalid :scope for use Storex.Store — expected :session, :global or {:key, binary}, got: #{inspect(other)}"
   end
 
   @doc false
@@ -118,35 +203,50 @@ defmodule Storex.Store do
     end
   end
 
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
+    scope = opts |> Keyword.get(:scope, :session) |> Storex.Store.__validate_scope__()
+
     quote do
       @behaviour Storex.Store
+
+      @storex_scope unquote(Macro.escape(scope))
+
+      @doc false
+      def __storex_scope__, do: @storex_scope
 
       @before_compile Storex.Store
     end
   end
 
   defmacro __before_compile__(env) do
+    scope = Module.get_attribute(env.module, :storex_scope) || :session
+
     quote do
       defmodule Server do
         use GenServer
 
         @store unquote(env.module)
 
-        def init({session, init_state, params}) do
+        def init({session, store, init_state, params, key}) do
           {:ok,
            %{
              state: init_state,
              session: session,
-             params: params
+             store: store,
+             params: params,
+             key: key
            }}
         end
 
-        def start_link([], session: session, store: store, params: params) do
-          opts = [name: Storex.Supervisor.name(session, store)]
+        def start_link([], opts) do
+          session = Keyword.fetch!(opts, :session)
+          store = Keyword.fetch!(opts, :store)
+          params = Keyword.fetch!(opts, :params)
+          name = Keyword.get(opts, :name) || Storex.Supervisor.name(session, store)
 
           with {:ok, state, key} <- init_store(session, params),
-               {:ok, pid} <- GenServer.start_link(Server, {session, state, params}, opts) do
+               {:ok, pid} <-
+                 GenServer.start_link(Server, {session, store, state, params, key}, name: name) do
             {:ok, pid, %{session: session, key: key}}
           else
             {:error, reason} -> {:error, reason}
@@ -163,18 +263,30 @@ defmodule Storex.Store do
           {:reply, state.state, state}
         end
 
-        def handle_call({name, data}, _, state) do
-          Storex.Store.__mutation__(@store, name, data, state.session, state.params, state.state)
+        # Asked by `Storex.Supervisor` when a session attaches to a store process
+        # that is already running. The key belongs to the `init/2` that started
+        # it, and the process is the only place that is guaranteed to hold it —
+        # the registry row of the session that started it may not be written yet.
+        def handle_call(:get_key, _, state) do
+          {:reply, state.key, state}
+        end
+
+        # `from_session` is the session that issued the mutation, which is not
+        # necessarily the one `init/2` ran with: under a shared scope many
+        # sessions call into the same process. It is what `mutation/5` is given,
+        # so a shared store can tell its clients apart.
+        def handle_call({:mutation, name, data, from_session}, _, state) do
+          Storex.Store.__mutation__(@store, name, data, from_session, state.params, state.state)
           |> case do
             {:reply, message, result} ->
               diff = Storex.Diff.check(state.state, result)
-              state = Map.put(state, :state, result)
-              {:reply, {:ok, message, diff}, state}
+              broadcast_diff(diff, from_session, state)
+              {:reply, {:ok, message, diff}, Map.put(state, :state, result)}
 
             {:noreply, result} ->
               diff = Storex.Diff.check(state.state, result)
-              state = Map.put(state, :state, result)
-              {:reply, {:ok, diff}, state}
+              broadcast_diff(diff, from_session, state)
+              {:reply, {:ok, diff}, Map.put(state, :state, result)}
 
             {:error, error} ->
               {:reply, {:error, error}, state}
@@ -185,9 +297,35 @@ defmodule Storex.Store do
           raise "Not handled call: #{inspect(call)}"
         end
 
+        unquote(broadcast_diff(scope))
+
         defp init_store(session, params) do
           Storex.Store.__init__(@store, session, params)
         end
+      end
+    end
+  end
+
+  # Under `:session` scope a store process has exactly one session, so the
+  # session that issued the mutation is the only one there is and the reply
+  # carries the diff already. Generating the fan-out away rather than branching
+  # on the scope at runtime keeps the existing path at zero added cost.
+  defp broadcast_diff(:session) do
+    quote do
+      defp broadcast_diff(_diff, _from_session, _state), do: :ok
+    end
+  end
+
+  defp broadcast_diff(_shared) do
+    quote do
+      defp broadcast_diff([], _from_session, _state), do: :ok
+
+      defp broadcast_diff(diff, from_session, state) do
+        Storex.Registry.store_sessions(self())
+        |> Enum.each(fn
+          {^from_session, _session_pid} -> :ok
+          {_session, session_pid} -> send(session_pid, {:storex_diff, state.store, diff})
+        end)
       end
     end
   end

--- a/lib/storex/supervisor.ex
+++ b/lib/storex/supervisor.ex
@@ -21,39 +21,74 @@ defmodule Storex.Supervisor do
   # `:"#{session}_#{store}"` created one permanent atom per session-store pair
   # and eventually exhausted the atom table on a long-running node.
   #
-  # Nothing looks a store up by this name — `Storex.Registry` maps to the pid
-  # for that. It exists so that starting the same `{session, store}` twice
-  # fails with `{:error, {:already_started, pid}}` instead of silently
-  # producing a second process.
-  def name(session, store) do
-    {:via, Registry, {Storex.StoreRegistry, {session, store}}}
+  # The first element is the store's *scope id* (`Storex.Store.scope_id/3`), not
+  # the session — for the default `:session` scope the two are the same value,
+  # which is why nothing changes for stores that do not opt into a shared scope.
+  # Sessions sharing a scope id resolve to the same name, and therefore to one
+  # process and one state.
+  def name(scope, store) do
+    {:via, Registry, {Storex.StoreRegistry, {scope, store}}}
   end
 
   def add_store(store, session, session_pid, params \\ %{}) do
     Storex.Registry.get_store(store, session)
     |> case do
-      :undefined ->
-        store_server = Module.concat([store, "Server"])
-
-        spec = %{
-          id: store_server,
-          start: {store_server, :start_link, [[session: session, store: store, params: params]]},
-          restart: :transient
-        }
-
-        DynamicSupervisor.start_child(__MODULE__, spec)
-        |> case do
-          {:ok, store_pid, %{key: key}} ->
-            Storex.Registry.register_store(store, store_pid, session, session_pid, key)
-            {:ok, key}
-
-          {:error, error} ->
-            {:error, error}
-        end
-
       {_, _, _, _, key} ->
         {:ok, key}
+
+      :undefined ->
+        with {:ok, module} <- resolve(store),
+             {:ok, scope} <- Storex.Store.scope_id(module, session, params),
+             {:ok, store_pid, key} <- start_or_attach(module, store, scope, session, params) do
+          Storex.Registry.register_store(store, store_pid, session, session_pid, key)
+          {:ok, key}
+        end
     end
+  end
+
+  defp resolve(store) do
+    Storex.Store.resolve(store)
+    |> case do
+      {:ok, module} -> {:ok, module}
+      {:error, _} -> {:error, "Store '#{store}' is not defined or can't be compiled."}
+    end
+  end
+
+  # A store process that is already running under this scope is attached to
+  # rather than started again. Looking the name up before starting matters for
+  # shared scopes: relying on `{:error, {:already_started, _}}` alone would run
+  # the user's `init/2`, side effects included, and then throw the result away.
+  # The lookup narrows that to a genuine race between two sessions attaching at
+  # the same moment, which the `:already_started` branch still covers.
+  defp start_or_attach(module, store, scope, session, params) do
+    Registry.lookup(Storex.StoreRegistry, {scope, store})
+    |> case do
+      [{store_pid, _}] -> attach(store_pid)
+      [] -> start(module, store, scope, session, params)
+    end
+  end
+
+  defp start(module, store, scope, session, params) do
+    server = Module.concat(module, Server)
+
+    spec = %{
+      id: server,
+      start:
+        {server, :start_link,
+         [[session: session, store: store, params: params, name: name(scope, store)]]},
+      restart: :transient
+    }
+
+    DynamicSupervisor.start_child(__MODULE__, spec)
+    |> case do
+      {:ok, store_pid, %{key: key}} -> {:ok, store_pid, key}
+      {:error, {:already_started, store_pid}} -> attach(store_pid)
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp attach(store_pid) do
+    {:ok, store_pid, GenServer.call(store_pid, :get_key)}
   end
 
   # `:sys.get_state/1` is a debug function, and using it here meant reading the
@@ -77,14 +112,27 @@ defmodule Storex.Supervisor do
         {:error, "Store '#{store}' is not joined in this session."}
 
       pid ->
-        GenServer.call(pid, {name, data})
+        GenServer.call(pid, {:mutation, name, data, session})
     end
   end
 
+  # Under a shared scope the store process outlives the session that leaves, so
+  # it is stopped only once the registry holds no session for it any more. The
+  # row goes first: counting before the delete would always find this session.
   def remove_store(session, store) do
-    Storex.Registry.get_store_pid(store, session)
-    |> GenServer.cast(:session_ended)
-
+    store_pid = Storex.Registry.get_store_pid(store, session)
     Storex.Registry.unregister_store(store, session)
+
+    case store_pid do
+      :undefined ->
+        :ok
+
+      pid ->
+        if Storex.Registry.store_sessions(pid) == [] do
+          GenServer.cast(pid, :session_ended)
+        else
+          :ok
+        end
+    end
   end
 end

--- a/test/fixtures/stores/room.ex
+++ b/test/fixtures/stores/room.ex
@@ -1,0 +1,36 @@
+defmodule StorexTest.Store.Room do
+  @moduledoc """
+  Scoped by the `"room"` param: every session that joins with the same room
+  value shares one process and one state.
+
+  Reports `init/2` and `terminate/3` to the pid found under the `"reporter"`
+  param, which is kept out of the state so the state stays JSON encodable.
+  """
+
+  use Storex.Store, scope: {:key, "room"}
+
+  def init(session, params) do
+    report(params, {:initialized, session})
+
+    {:ok, %{counter: 0, last: nil}}
+  end
+
+  def mutation("increase", _data, session, _params, state) do
+    {:noreply, %{state | counter: state.counter + 1, last: session}}
+  end
+
+  def mutation("noop", _data, _session, _params, state) do
+    {:noreply, state}
+  end
+
+  def terminate(session, params, state) do
+    report(params, {:terminated, session, params, state})
+  end
+
+  defp report(params, message) do
+    case Map.get(params, "reporter") do
+      nil -> :ok
+      pid -> send(pid, message)
+    end
+  end
+end

--- a/test/fixtures/stores/shared.ex
+++ b/test/fixtures/stores/shared.ex
@@ -1,0 +1,15 @@
+defmodule StorexTest.Store.Shared do
+  @moduledoc """
+  A `:global` store — one process, one state, for the whole node.
+  """
+
+  use Storex.Store, scope: :global
+
+  def init(_session, _params) do
+    {:ok, %{counter: 0}}
+  end
+
+  def mutation("increase", _data, _session, _params, state) do
+    {:noreply, %{state | counter: state.counter + 1}}
+  end
+end

--- a/test/storex/handler/plug_test.exs
+++ b/test/storex/handler/plug_test.exs
@@ -294,6 +294,82 @@ defmodule StorexTest.Handler.Plug do
     end
   end
 
+  describe "shared scope" do
+    test "a mutation by one session is pushed to the others sharing the store", context do
+      room = "room-#{random_string()}"
+
+      a = tcp_client(context)
+      http1_handshake(a, Storex.Handler.Plug)
+
+      b = tcp_client(context)
+      http1_handshake(b, Storex.Handler.Plug)
+
+      [session_a, _session_b] =
+        for client <- [a, b] do
+          send_text_frame(client, """
+          {
+            "type": "join",
+            "store": "StorexTest.Store.Room",
+            "data": {"room": "#{room}"},
+            "request": "#{random_string()}"
+          }
+          """)
+
+          {:ok, joined} = recv_text_frame(client)
+
+          assert %{type: "join", data: %{counter: 0}, session: session} =
+                   Jason.decode!(joined, keys: :atoms)
+
+          session
+        end
+
+      request = random_string()
+
+      send_text_frame(a, """
+      {
+        "type": "mutation",
+        "store": "StorexTest.Store.Room",
+        "data": {"name": "increase", "data": []},
+        "session": "#{session_a}",
+        "request": "#{request}"
+      }
+      """)
+
+      # The mutating session gets the diff as the reply to its own request.
+      {:ok, reply} = recv_text_frame(a)
+
+      assert %{type: "mutation", request: ^request, diff: diff} =
+               Jason.decode!(reply, keys: :atoms)
+
+      assert Enum.any?(diff, &match?(%{a: "u", p: ["counter"], t: 1}, &1))
+
+      # The other one is pushed the same diff, with no request to resolve.
+      {:ok, pushed} = recv_text_frame(b)
+
+      assert %{type: "mutation", request: nil, diff: ^diff, store: "StorexTest.Store.Room"} =
+               Jason.decode!(pushed, keys: :atoms)
+    end
+
+    test "joining without the scope param is an error frame, not a close", context do
+      client = tcp_client(context)
+      http1_handshake(client, Storex.Handler.Plug)
+
+      send_text_frame(client, """
+      {
+        "type": "join",
+        "store": "StorexTest.Store.Room",
+        "data": {},
+        "request": "#{random_string()}"
+      }
+      """)
+
+      {:ok, result} = recv_text_frame(client)
+
+      assert %{type: "error", error: error} = Jason.decode!(result, keys: :atoms)
+      assert error =~ "scoped by param \"room\""
+    end
+  end
+
   # Simple WebSocket client
 
   def tcp_client(context) do

--- a/test/storex/scope_test.exs
+++ b/test/storex/scope_test.exs
@@ -1,0 +1,283 @@
+defmodule StorexTest.ScopeTest do
+  use ExUnit.Case, async: false
+
+  @counter "StorexTest.Store.Counter"
+  @room "StorexTest.Store.Room"
+  @shared "StorexTest.Store.Shared"
+
+  defp session, do: "session-#{System.unique_integer([:positive])}"
+  defp room, do: "room-#{System.unique_integer([:positive])}"
+
+  defp join(store, session, params) do
+    result = Storex.Supervisor.add_store(store, session, self(), params)
+    on_exit(fn -> Storex.Supervisor.remove_store(session, store) end)
+    result
+  end
+
+  describe "scope resolution" do
+    test "a store without the option is :session scoped" do
+      assert Storex.Store.scope(StorexTest.Store.Counter) == :session
+      assert Storex.Store.scope_id(StorexTest.Store.Counter, "s", %{}) == {:ok, "s"}
+    end
+
+    test ":global resolves to the same id for every session" do
+      assert Storex.Store.scope(StorexTest.Store.Shared) == :global
+      assert Storex.Store.scope_id(StorexTest.Store.Shared, "a", %{}) == {:ok, :global}
+      assert Storex.Store.scope_id(StorexTest.Store.Shared, "b", %{}) == {:ok, :global}
+    end
+
+    test "{:key, _} resolves to the param value" do
+      assert Storex.Store.scope(StorexTest.Store.Room) == {:key, "room"}
+
+      assert Storex.Store.scope_id(StorexTest.Store.Room, "a", %{"room" => "lobby"}) ==
+               {:ok, {"room", "lobby"}}
+    end
+
+    test "{:key, _} without the param is an error, not a crash" do
+      assert Storex.Store.scope_id(StorexTest.Store.Room, "a", %{}) ==
+               {:error,
+                "Store StorexTest.Store.Room is scoped by param \"room\", which was not given."}
+
+      # Params are whatever the client sent — a non-map must not raise either.
+      assert {:error, _} = Storex.Store.scope_id(StorexTest.Store.Room, "a", "not a map")
+    end
+
+    test "an unknown scope is refused at compile time" do
+      assert_raise ArgumentError, ~r/invalid :scope for use Storex.Store/, fn ->
+        Code.eval_string("""
+        defmodule StorexTest.Store.BadScope#{System.unique_integer([:positive])} do
+          use Storex.Store, scope: :nope
+        end
+        """)
+      end
+    end
+  end
+
+  describe ":session scope" do
+    test "two sessions get two processes and two states" do
+      a = session()
+      b = session()
+
+      {:ok, _} = join(@counter, a, %{})
+      {:ok, _} = join(@counter, b, %{})
+
+      pid_a = Storex.Registry.get_store_pid(@counter, a)
+      pid_b = Storex.Registry.get_store_pid(@counter, b)
+
+      refute pid_a == pid_b
+
+      {:ok, _} = Storex.Supervisor.mutate_store(a, @counter, "increase", [])
+
+      assert Storex.Supervisor.get_store_state(a, @counter) == {:ok, %{counter: 1}}
+      assert Storex.Supervisor.get_store_state(b, @counter) == {:ok, %{counter: 0}}
+    end
+
+    test "a mutation pushes no diff to anybody else" do
+      a = session()
+      {:ok, _} = join(@counter, a, %{})
+
+      {:ok, _} = Storex.Supervisor.mutate_store(a, @counter, "increase", [])
+
+      refute_receive {:storex_diff, _, _}, 100
+    end
+  end
+
+  describe "shared scope" do
+    test "sessions with the same key share one process and one state" do
+      a = session()
+      b = session()
+      room = room()
+
+      {:ok, _} = join(@room, a, %{"room" => room})
+      {:ok, _} = join(@room, b, %{"room" => room})
+
+      pid_a = Storex.Registry.get_store_pid(@room, a)
+      pid_b = Storex.Registry.get_store_pid(@room, b)
+
+      assert pid_a == pid_b
+      assert [{^pid_a, nil}] = Registry.lookup(Storex.StoreRegistry, {{"room", room}, @room})
+
+      {:ok, _} = Storex.Supervisor.mutate_store(a, @room, "increase", [])
+
+      assert {:ok, %{counter: 1}} = Storex.Supervisor.get_store_state(b, @room)
+    end
+
+    test "sessions with different keys do not share" do
+      a = session()
+      b = session()
+
+      {:ok, _} = join(@room, a, %{"room" => room()})
+      {:ok, _} = join(@room, b, %{"room" => room()})
+
+      refute Storex.Registry.get_store_pid(@room, a) ==
+               Storex.Registry.get_store_pid(@room, b)
+    end
+
+    test "init/2 runs once, for the session that attaches first" do
+      a = session()
+      b = session()
+      room = room()
+
+      {:ok, _} = join(@room, a, %{"room" => room, "reporter" => self()})
+      assert_receive {:initialized, ^a}, 1000
+
+      {:ok, _} = join(@room, b, %{"room" => room, "reporter" => self()})
+      refute_receive {:initialized, ^b}, 100
+    end
+
+    test "a missing scope param is reported to the caller" do
+      assert {:error, message} = Storex.Supervisor.add_store(@room, session(), self(), %{})
+      assert message =~ "scoped by param \"room\""
+    end
+
+    test "mutation/5 is given the session that issued it, not the one init/2 ran with" do
+      a = session()
+      b = session()
+      room = room()
+
+      {:ok, _} = join(@room, a, %{"room" => room})
+      {:ok, _} = join(@room, b, %{"room" => room})
+
+      {:ok, _} = Storex.Supervisor.mutate_store(b, @room, "increase", [])
+
+      assert {:ok, %{last: ^b}} = Storex.Supervisor.get_store_state(a, @room)
+    end
+  end
+
+  describe "shared scope diff fan-out" do
+    test "the other sessions are pushed the diff, the mutating one is not" do
+      a = session()
+      b = session()
+      room = room()
+
+      {:ok, _} = join(@room, a, %{"room" => room})
+      {:ok, _} = join(@room, b, %{"room" => room})
+
+      {:ok, diff} = Storex.Supervisor.mutate_store(a, @room, "increase", [])
+
+      # Both sessions registered this process as their session pid, so exactly
+      # one push means session b was sent the diff and session a was not: it
+      # already has it, as the reply to its own call.
+      assert_receive {:storex_diff, @room, ^diff}, 1000
+      refute_receive {:storex_diff, @room, _}, 100
+
+      assert Enum.any?(diff, &match?(%{a: "u", p: [:counter], t: 1}, &1))
+    end
+
+    test "an empty diff is not pushed" do
+      a = session()
+      b = session()
+      room = room()
+
+      {:ok, _} = join(@room, a, %{"room" => room})
+      {:ok, _} = join(@room, b, %{"room" => room})
+
+      assert {:ok, []} = Storex.Supervisor.mutate_store(a, @room, "noop", [])
+
+      refute_receive {:storex_diff, _, _}, 100
+    end
+  end
+
+  describe "shared scope lifetime" do
+    test "the process outlives a session that leaves and stops with the last one" do
+      a = session()
+      b = session()
+      room = room()
+
+      {:ok, _} = join(@room, a, %{"room" => room, "reporter" => self()})
+      {:ok, _} = join(@room, b, %{"room" => room})
+
+      pid = Storex.Registry.get_store_pid(@room, a)
+      assert_receive {:initialized, ^a}, 1000
+
+      Storex.Supervisor.remove_store(a, @room)
+
+      refute_receive {:terminated, _, _, _}, 100
+      assert Process.alive?(pid)
+      assert Storex.Registry.get_store_pid(@room, b) == pid
+
+      Storex.Supervisor.remove_store(b, @room)
+
+      # terminate/3 is given the session and params init/2 ran with, which is
+      # session a — the one that is already gone.
+      assert_receive {:terminated, ^a, %{"room" => ^room}, %{counter: 0}}, 1000
+    end
+
+    test "the scope name is released once the last session leaves" do
+      a = session()
+      room = room()
+
+      {:ok, _} = join(@room, a, %{"room" => room})
+      assert [{_, nil}] = Registry.lookup(Storex.StoreRegistry, {{"room", room}, @room})
+
+      Storex.Supervisor.remove_store(a, @room)
+
+      assert eventually(fn ->
+               Registry.lookup(Storex.StoreRegistry, {{"room", room}, @room}) == []
+             end)
+    end
+  end
+
+  describe "Storex.mutate/3 against a shared store" do
+    test "the mutation is dispatched once per store process, not once per session" do
+      a = session()
+      b = session()
+      room = room()
+
+      {:ok, _} = join(@room, a, %{"room" => room})
+      {:ok, _} = join(@room, b, %{"room" => room})
+
+      # Both sessions registered this process as their session pid. A shared
+      # store must run the mutation once against the state they share, so the
+      # fan-out has to reach one of them and not both.
+      Storex.mutate(@room, "increase", [])
+
+      assert_receive {:mutate, @room, "increase", []}, 1000
+      refute_receive {:mutate, @room, "increase", []}, 100
+    end
+
+    test "a :session scoped store is still reached once per session" do
+      a = session()
+      b = session()
+
+      {:ok, _} = join(@counter, a, %{})
+      {:ok, _} = join(@counter, b, %{})
+
+      Storex.mutate(@counter, "increase", [])
+
+      assert_receive {:mutate, @counter, "increase", []}, 1000
+      assert_receive {:mutate, @counter, "increase", []}, 1000
+    end
+  end
+
+  describe ":global scope" do
+    test "every session on the node lands on the same process" do
+      a = session()
+      b = session()
+
+      {:ok, _} = join(@shared, a, %{})
+      {:ok, _} = join(@shared, b, %{})
+
+      pid = Storex.Registry.get_store_pid(@shared, a)
+
+      assert Storex.Registry.get_store_pid(@shared, b) == pid
+      assert [{^pid, nil}] = Registry.lookup(Storex.StoreRegistry, {:global, @shared})
+
+      {:ok, _} = Storex.Supervisor.mutate_store(a, @shared, "increase", [])
+
+      assert {:ok, %{counter: counter}} = Storex.Supervisor.get_store_state(b, @shared)
+      assert counter > 0
+    end
+  end
+
+  defp eventually(check, attempts \\ 100) do
+    Enum.reduce_while(1..attempts, false, fn _, _ ->
+      if check.() do
+        {:halt, true}
+      else
+        Process.sleep(10)
+        {:cont, false}
+      end
+    end)
+  end
+end


### PR DESCRIPTION
Storex has always started one store process per `{session, store}` pair, so two
connections to the same store module hold two independent states. Anything where
the state *is* the shared thing — a chat room, a collaborative document, a
dashboard several people watch — could not be expressed. The workaround was an
external source of truth plus `Storex.mutate/3`, which fans out over `:pg` and
re-runs `mutation/5` once per session, so the callback had to be written to
survive running N times against N independent copies of the same state.

`use Storex.Store` now takes a `:scope`:

```elixir
scope: :session         # the default, and what it has always done
scope: :global          # one process for the whole node
scope: {:key, "room"}   # one process per params["room"] value
```

A scope decides the identity a store process registers under.
`Storex.Store.scope_id/3` derives it and `Storex.Supervisor.name/2` takes that
scope id where it used to take a session. For `:session` the scope id *is* the
session, so stores that do not pass the option resolve to exactly the processes
and names they did before.

Under a shared scope several sessions call into one process. A mutation is
applied once, the diff is computed once, and it reaches every attached session:
the one that issued it as the reply to its own request, the rest as a push. The
push is a new `{:storex_diff, ...}` message, encoded by
`Storex.Socket.diff_handle/3` and sent by both handlers. The fan-out is
generated away for `:session` scope rather than branched on at runtime, so the
existing path pays nothing for it.

## What sharing a process changes about the callbacks

- `init/2` runs once, for the first session to attach. The params of every
  session that attaches later are ignored.
- `mutation/5` receives the session that *issued* the mutation rather than the
  one `init/2` ran with, so a shared store can tell its clients apart. Under
  `:session` scope those are the same value.
- `terminate/3` runs when the last session detaches.
  `Storex.Supervisor.remove_store/2` reference counts to make that true: the
  registry row is deleted first, then the process is stopped only if no session
  is left.

## Attaching instead of starting

`Storex.Supervisor.add_store/4` looks the scope up in `Storex.StoreRegistry`
before starting anything. Relying on `{:error, {:already_started, _}}` alone
would run the user's `init/2`, side effects included, and then throw the result
away. The lookup narrows that to a genuine race between two sessions attaching
at the same moment, which the `:already_started` branch still covers. The key an
attaching session reports comes from the process itself, through a new
`:get_key` call, because the registry row of the session that started it may not
be written yet.

## Broadcast dispatch

`Storex.PG` now dispatches a broadcast once per store *process* instead of once
per registry row. Without that a shared store would run a `Storex.mutate/3`
mutation once per attached session against the state they all share. Nothing
changes for `:session` scoped stores, where every row already has a process of
its own.

## The registry table is unchanged

A shared store is several rows pointing at one `store_pid`, so none of the match
patterns in `registry.ex`, `pg.ex` and the handlers had to move.
`Storex.Registry.store_sessions/1` is the one new read, and it backs both the
fan-out and the reference count.

## The frontend needs no change

The client already falls through to its mutation listeners for a `mutation`
frame whose `request` matches no pending promise, and filters on store and
session; the pushed frame carries the receiving session's own id, so it matches.
No rebuilt bundles in `priv/static`.

## Limitations

`:global` is per node, not per cluster. `Storex.StoreRegistry` is node-local and
`Storex.mutate/3` broadcasts to every node, so a `:global` store takes a mutation
once per node, against that node's own copy of the state. Cluster-wide
singletons need `:global`, Horde or an owning-node rule, and are not attempted
here.

`Storex.Store.scope/1` checks `Code.ensure_loaded?/1` before
`function_exported?/3`. Asking the latter alone answers `false` for a module that
is not loaded yet — the same trap `__terminate__/4` fell into — and every store
then silently degrades to `:session` scope depending on what the code server
happens to hold.

## Tests

`test/storex/scope_test.exs` covers scope resolution, sharing, isolation between
keys, the diff fan-out, the reference count and the `Storex.mutate/3` dedupe.
Two end-to-end tests in `test/storex/handler/plug_test.exs` drive two real
sockets through a shared store. 136 non-browser tests pass on three seeds;
`mix compile --warnings-as-errors` and `mix format --check-formatted` are clean.
The 21 browser tests still need chromedriver and did not run here.
