### PR TITLE
Add Storex.Test for driving a store from a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # storex
 
+## Unreleased
+
+- Added `Storex.Test`, a supported way to drive a store from a test with no socket and no browser. `start_store/2`, `state/1`, `commit/3`, `broadcast/4` and `stop/1` cover starting a store (including a store whose `init/2` refuses), reading its state, running a mutation and getting back the state, the diff and any reply, running a `Storex.mutate/3` fan-out and applying it, and stopping the store synchronously so a test can assert on what `terminate/3` did. Until now this meant going through `Storex.Supervisor` and `Storex.Registry`, both `@moduledoc false`, or driving a real browser through Wallaby. The diff is the reason it exists: it is the contract with the frontend and there was no other way to assert on it. A store started this way registers the calling process as its session and is stopped when the test ends
+
 ## 0.7.0
 
 - **[BREAKING]** Updated the minimum required version of Elixir to `1.16`

--- a/README.md
+++ b/README.md
@@ -177,6 +177,48 @@ store.onDisconnected((closeEvent) => {
 })
 ```
 
+## Testing
+
+`Storex.Test` drives a store with no socket and no browser:
+
+```elixir
+defmodule MyApp.Store.CounterTest do
+  use ExUnit.Case
+
+  test "increasing counts up" do
+    store = Storex.Test.start_store!(MyApp.Store.Counter)
+
+    assert {:ok, result} = Storex.Test.commit(store, "increase")
+
+    assert result.state == %{counter: 1}
+    assert result.diff == [%{a: "u", p: [:counter], t: 1}]
+  end
+end
+```
+
+`result.diff` is the point: the diff is what actually goes over the wire, and it
+is the part a store author cannot otherwise get at without driving a browser.
+`result.message` carries the reply from a `{:reply, message, state}` mutation.
+
+A mutation that errors — a name no clause matches, an `{:error, reason}` return
+— comes back as `{:error, reason}`, the same thing the client would have
+received as an error frame. `commit!/3` raises instead, for the cases a test
+does not mean to assert on.
+
+```elixir
+store = Storex.Test.start_store!(MyApp.Store.Counter, params: %{"start" => 10})
+
+Storex.Test.state(store)                    # current state
+Storex.Test.commit!(store, "set", [3])      # mutate, raising on error
+Storex.Test.broadcast(store, "reload")      # as Storex.mutate/3 does, applied
+Storex.Test.stop(store)                     # runs terminate/3 and waits for it
+```
+
+`start_store/2` returns `{:error, reason}` when the store's `init/2` does, so
+refusing to start is testable too. The calling process is registered as the
+session, and the store is stopped for you when the test ends.
+
+
 ## Connectors
 The default export of `useStorex` uses WebSocket connections only, you can extend it by using custom connector.
 

--- a/lib/storex/test.ex
+++ b/lib/storex/test.ex
@@ -1,0 +1,223 @@
+defmodule Storex.Test do
+  @moduledoc """
+  Drives a store from a test, with no socket and no browser.
+
+  Everything a store does is reachable through `Storex.Supervisor` and
+  `Storex.Registry`, but both are `@moduledoc false` — a test written against
+  them is written against internals that are free to move. This is the supported
+  way.
+
+      defmodule MyApp.Store.CounterTest do
+        use ExUnit.Case
+
+        test "increasing counts up" do
+          store = Storex.Test.start_store!(MyApp.Store.Counter)
+
+          assert {:ok, result} = Storex.Test.commit(store, "increase")
+
+          assert result.state == %{counter: 1}
+          assert result.diff == [%{a: "u", p: [:counter], t: 1}]
+        end
+      end
+
+  `result.diff` is the reason this exists. The diff is the contract with the
+  frontend — it is what actually goes over the wire — and it is the part a store
+  author cannot otherwise get at without a browser.
+
+  ## The calling process is the session
+
+  A store started here registers the calling process as its session, the way a
+  socket process would. That is what makes `broadcast/4` able to observe a
+  `Storex.mutate/3` fan-out, and it means a store is cleaned up when the test
+  ends: `start_store/2` registers an `ExUnit` `on_exit` callback that calls
+  `stop/1`. Outside ExUnit nothing is registered and `stop/1` is yours to call.
+  """
+
+  @enforce_keys [:store, :session, :key]
+  defstruct [:store, :session, :key]
+
+  @type t :: %__MODULE__{store: binary(), session: binary(), key: binary() | nil}
+
+  @type result :: %{state: any(), diff: list(), message: any()}
+
+  @doc """
+  Starts a store and attaches the calling process to it as a session.
+
+  Takes the store module, or the name a client would send. Options:
+
+  - `:params` - the params `init/2` is given. Defaults to `%{}`. Keys are
+    binaries, as they are when they arrive from a client.
+  - `:session` - the session id. Defaults to a unique one per call.
+  - `:session_pid` - the process standing in for the socket. Defaults to the
+    caller, which is what `broadcast/4` needs.
+
+  Returns `{:error, reason}` when the store's `init/2` does, so that refusing to
+  start is testable.
+  """
+  @spec start_store(module() | binary(), keyword()) :: {:ok, t()} | {:error, any()}
+  def start_store(store, opts \\ []) do
+    store = name(store)
+    session = Keyword.get_lazy(opts, :session, &unique_session/0)
+    session_pid = Keyword.get(opts, :session_pid, self())
+    params = Keyword.get(opts, :params, %{})
+
+    case Storex.Supervisor.add_store(store, session, session_pid, params) do
+      {:ok, key} ->
+        handle = %__MODULE__{store: store, session: session, key: key}
+        cleanup(handle)
+        {:ok, handle}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Same as `start_store/2`, raising when the store refuses to start.
+  """
+  @spec start_store!(module() | binary(), keyword()) :: t()
+  def start_store!(store, opts \\ []) do
+    case start_store(store, opts) do
+      {:ok, handle} ->
+        handle
+
+      {:error, reason} ->
+        raise "store #{inspect(name(store))} did not start: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  The store's current state.
+
+  Raises if the store is not running, which in a test is a failure rather than
+  an outcome to assert on.
+  """
+  @spec state(t()) :: any()
+  def state(%__MODULE__{} = handle) do
+    case Storex.Supervisor.get_store_state(handle.session, handle.store) do
+      {:ok, state} -> state
+      {:error, reason} -> raise reason
+    end
+  end
+
+  @doc """
+  Runs a mutation, the way a `commit` from the client does.
+
+  Returns `{:ok, result}` where `result` is a map of:
+
+  - `:state` - the store's state after the mutation
+  - `:diff` - the diff the client would have been sent
+  - `:message` - the reply from `{:reply, message, state}`, or `nil`
+
+  `{:error, reason}` is what the client would have received as an error frame:
+  a mutation returning `{:error, reason}`, a name no clause matches, or an
+  unsupported return value.
+  """
+  @spec commit(t(), binary(), any()) :: {:ok, result()} | {:error, any()}
+  def commit(%__MODULE__{} = handle, name, data \\ []) do
+    Storex.Supervisor.mutate_store(handle.session, handle.store, name, data)
+    |> case do
+      {:ok, diff} -> {:ok, result(handle, diff, nil)}
+      {:ok, message, diff} -> {:ok, result(handle, diff, message)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Same as `commit/3`, raising when the mutation errors.
+  """
+  @spec commit!(t(), binary(), any()) :: result()
+  def commit!(%__MODULE__{} = handle, name, data \\ []) do
+    case commit(handle, name, data) do
+      {:ok, result} -> result
+      {:error, reason} -> raise "mutation #{inspect(name)} failed: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Runs a mutation the way `Storex.mutate/3` and `Storex.mutate/4` do, through
+  the cluster fan-out, and applies what comes back.
+
+  `Storex.mutate/3` broadcasts over `:pg` and sends the mutation to each
+  session's *socket* process, which is what normally turns it into a call on the
+  store. There is no socket here, so this waits for that message and applies it,
+  giving back the same result as `commit/3`.
+
+  Options:
+
+  - `:key` - filter on the key `init/2` returned, as `Storex.mutate/4` does.
+  - `:timeout` - how long to wait for the fan-out. Defaults to 1000ms.
+
+  Requires the session pid to be the calling process, which is the default.
+  Returns `{:error, :timeout}` when nothing arrives, which is the assertion for
+  a store the fan-out should *not* have reached.
+  """
+  @spec broadcast(t(), binary(), any(), keyword()) :: {:ok, result()} | {:error, any()}
+  def broadcast(%__MODULE__{} = handle, name, data \\ [], opts \\ []) do
+    store = handle.store
+    timeout = Keyword.get(opts, :timeout, 1000)
+
+    case Keyword.fetch(opts, :key) do
+      {:ok, key} -> Storex.mutate(key, store, name, data)
+      :error -> Storex.mutate(store, name, data)
+    end
+
+    receive do
+      {:mutate, ^store, ^name, payload} -> commit(handle, name, payload)
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  @doc """
+  Stops the store, running `terminate/3` if it defines one.
+
+  Waits for the process to go down, so a test can assert on what `terminate/3`
+  did on the line after. `Storex.Supervisor.remove_store/2` is a cast, and
+  asserting on its effects without waiting is a race.
+  """
+  @spec stop(t(), timeout()) :: :ok
+  def stop(%__MODULE__{} = handle, timeout \\ 1000) do
+    case Storex.Registry.get_store_pid(handle.store, handle.session) do
+      :undefined ->
+        :ok
+
+      pid ->
+        reference = Process.monitor(pid)
+        Storex.Supervisor.remove_store(handle.session, handle.store)
+
+        receive do
+          {:DOWN, ^reference, :process, ^pid, _reason} -> :ok
+        after
+          timeout ->
+            Process.demonitor(reference, [:flush])
+            :ok
+        end
+    end
+  end
+
+  defp result(handle, diff, message) do
+    %{state: state(handle), diff: diff, message: message}
+  end
+
+  defp name(store) when is_atom(store), do: inspect(store)
+  defp name(store) when is_binary(store), do: store
+
+  defp unique_session, do: "storex-test-#{System.unique_integer([:positive])}"
+
+  # A store outlives the process that started it — `Storex.Registry` monitors the
+  # store, not the session — so without this every test that starts one leaks a
+  # process for the rest of the run. Reached through `apply/3` so that this
+  # module carries no compile-time reference to ExUnit, which is not there in
+  # the environments the library is actually built for.
+  defp cleanup(handle) do
+    if Code.ensure_loaded?(ExUnit.Callbacks) do
+      apply(ExUnit.Callbacks, :on_exit, [fn -> stop(handle) end])
+    end
+
+    :ok
+  rescue
+    # `on_exit/1` raises when it is not called from a test process.
+    ArgumentError -> :ok
+  end
+end

--- a/test/storex/test_test.exs
+++ b/test/storex/test_test.exs
@@ -1,0 +1,232 @@
+defmodule StorexTest.TestTest do
+  # Tests `Storex.Test`. Sync, because `broadcast/4` exercises the cluster
+  # fan-out, which reaches every session of a store on the node.
+  use ExUnit.Case, async: false
+
+  alias StorexTest.Store.Counter
+  alias StorexTest.Store.ErrorInit
+  alias StorexTest.Store.InvalidMutation
+  alias StorexTest.Store.KeyInit
+  alias StorexTest.Store.Terminating
+
+  describe "start_store/2" do
+    test "takes a module" do
+      assert {:ok, handle} = Storex.Test.start_store(Counter)
+
+      assert handle.store == "StorexTest.Store.Counter"
+      assert is_pid(Storex.Registry.get_store_pid(handle.store, handle.session))
+    end
+
+    test "takes the name a client would send" do
+      assert {:ok, handle} = Storex.Test.start_store("StorexTest.Store.Counter")
+      assert handle.store == "StorexTest.Store.Counter"
+    end
+
+    test "params reach init/2" do
+      assert {:ok, handle} =
+               Storex.Test.start_store(StorexTest.Store.Text, params: %{"initial_value" => "hi"})
+
+      assert Storex.Test.state(handle) == "hi"
+    end
+
+    test "the key from {:ok, state, key} is on the handle" do
+      assert {:ok, %{key: "user_id"}} = Storex.Test.start_store(KeyInit)
+    end
+
+    test "a store with no key has a nil one" do
+      assert {:ok, %{key: nil}} = Storex.Test.start_store(Counter)
+    end
+
+    test "sessions are unique per call" do
+      {:ok, one} = Storex.Test.start_store(Counter)
+      {:ok, two} = Storex.Test.start_store(Counter)
+
+      refute one.session == two.session
+
+      refute Storex.Registry.get_store_pid(one.store, one.session) ==
+               Storex.Registry.get_store_pid(two.store, two.session)
+    end
+
+    test "a session can be given" do
+      assert {:ok, %{session: "chosen"}} = Storex.Test.start_store(Counter, session: "chosen")
+    end
+
+    test "a store refusing to start is an error, not a raise" do
+      assert Storex.Test.start_store(ErrorInit) == {:error, "Unauthorized"}
+    end
+  end
+
+  describe "start_store!/2" do
+    test "returns the handle" do
+      assert %Storex.Test{} = Storex.Test.start_store!(Counter)
+    end
+
+    test "raises when the store refuses to start" do
+      assert_raise RuntimeError, ~r/did not start: "Unauthorized"/, fn ->
+        Storex.Test.start_store!(ErrorInit)
+      end
+    end
+  end
+
+  describe "state/1" do
+    test "reads the current state" do
+      handle = Storex.Test.start_store!(Counter)
+      assert Storex.Test.state(handle) == %{counter: 0}
+    end
+
+    test "raises for a store that is gone" do
+      handle = Storex.Test.start_store!(Counter)
+      Storex.Test.stop(handle)
+
+      assert_raise RuntimeError, ~r/is not joined in this session/, fn ->
+        Storex.Test.state(handle)
+      end
+    end
+  end
+
+  describe "commit/3" do
+    test "gives back the state, the diff and no message" do
+      handle = Storex.Test.start_store!(Counter)
+
+      assert {:ok, result} = Storex.Test.commit(handle, "increase")
+
+      assert result.state == %{counter: 1}
+      assert result.diff == [%{a: "u", p: [:counter], t: 1}]
+      assert result.message == nil
+    end
+
+    test "carries the reply of a {:reply, message, state} mutation" do
+      handle = Storex.Test.start_store!(Counter)
+
+      assert {:ok, %{message: "decreased", state: %{counter: -1}}} =
+               Storex.Test.commit(handle, "decrease")
+    end
+
+    test "passes data through" do
+      handle = Storex.Test.start_store!(StorexTest.Store.Text)
+
+      assert {:ok, %{state: "changed"}} = Storex.Test.commit(handle, "change", ["changed"])
+    end
+
+    test "a mutation returning an error is an error" do
+      handle = Storex.Test.start_store!(InvalidMutation)
+
+      assert Storex.Test.commit(handle, "error") == {:error, "Not allowed"}
+    end
+
+    test "a name no clause matches is an error" do
+      handle = Storex.Test.start_store!(Counter)
+
+      assert {:error, message} = Storex.Test.commit(handle, "nope", [1])
+      assert message =~ "No mutation matching \"nope\""
+    end
+
+    test "state is unchanged after an error" do
+      handle = Storex.Test.start_store!(InvalidMutation)
+
+      assert {:error, _} = Storex.Test.commit(handle, "error")
+      assert Storex.Test.state(handle) == %{counter: 0}
+    end
+
+    test "an empty diff is an empty list, not an absence" do
+      handle = Storex.Test.start_store!(StorexTest.Store.Text, params: %{"initial_value" => "x"})
+
+      assert {:ok, %{diff: []}} = Storex.Test.commit(handle, "change", ["x"])
+    end
+  end
+
+  describe "commit!/3" do
+    test "returns the result" do
+      handle = Storex.Test.start_store!(Counter)
+      assert %{state: %{counter: 1}} = Storex.Test.commit!(handle, "increase")
+    end
+
+    test "raises on an error" do
+      handle = Storex.Test.start_store!(InvalidMutation)
+
+      assert_raise RuntimeError, ~r/mutation "error" failed: "Not allowed"/, fn ->
+        Storex.Test.commit!(handle, "error")
+      end
+    end
+  end
+
+  describe "broadcast/4" do
+    test "applies a Storex.mutate/3 fan-out" do
+      handle = Storex.Test.start_store!(Counter)
+
+      assert {:ok, result} = Storex.Test.broadcast(handle, "increase")
+
+      assert result.state == %{counter: 1}
+      assert result.diff == [%{a: "u", p: [:counter], t: 1}]
+    end
+
+    test "filters on the key, like Storex.mutate/4" do
+      handle = Storex.Test.start_store!(KeyInit)
+
+      assert {:ok, %{state: %{counter: 5}}} =
+               Storex.Test.broadcast(handle, "set", [5], key: "user_id")
+    end
+
+    test "a key the store did not return never reaches it" do
+      handle = Storex.Test.start_store!(KeyInit)
+
+      assert Storex.Test.broadcast(handle, "set", [5], key: "somebody_else", timeout: 100) ==
+               {:error, :timeout}
+
+      assert Storex.Test.state(handle) == %{counter: 0}
+    end
+  end
+
+  describe "stop/1" do
+    test "runs terminate/3 with the state as of the last mutation" do
+      handle = Storex.Test.start_store!(Terminating, params: %{"reporter" => self()})
+      session = handle.session
+
+      {:ok, _} = Storex.Test.commit(handle, "increase")
+
+      assert Storex.Test.stop(handle) == :ok
+
+      # stop/1 waits for the process, so the message is already here.
+      assert_received {:terminated, ^session, _params, %{counter: 1}}
+    end
+
+    test "the process is gone when it returns" do
+      handle = Storex.Test.start_store!(Counter)
+      pid = Storex.Registry.get_store_pid(handle.store, handle.session)
+
+      Storex.Test.stop(handle)
+
+      refute Process.alive?(pid)
+      assert Storex.Registry.get_store_pid(handle.store, handle.session) == :undefined
+    end
+
+    test "stopping twice is fine" do
+      handle = Storex.Test.start_store!(Counter)
+
+      assert Storex.Test.stop(handle) == :ok
+      assert Storex.Test.stop(handle) == :ok
+    end
+  end
+
+  describe "cleanup" do
+    test "a store started here is stopped when the test ends" do
+      # `on_exit` runs callbacks last-registered-first, and it runs them in
+      # another process — hence the unlinked agent to carry the handle across.
+      # Registering before the store exists is what puts this assertion *after*
+      # the callback `start_store/2` registers.
+      {:ok, agent} = Agent.start(fn -> nil end)
+
+      on_exit(fn ->
+        handle = Agent.get(agent, & &1)
+        Agent.stop(agent)
+
+        assert Storex.Registry.get_store_pid(handle.store, handle.session) == :undefined
+      end)
+
+      handle = Storex.Test.start_store!(Counter)
+      Agent.update(agent, fn _ -> handle end)
+
+      assert is_pid(Storex.Registry.get_store_pid(handle.store, handle.session))
+    end
+  end
+end


### PR DESCRIPTION
Exercising a store today means going through `Storex.Supervisor.add_store/4` and
`mutate_store/4`, both `@moduledoc false` — a test written against them is
written against internals that are free to move. The alternative is the browser
suite, which needs real Chrome through Wallaby with chromedriver on PATH.

`Storex.Test` is the supported way:

```elixir
defmodule MyApp.Store.CounterTest do
  use ExUnit.Case

  test "increasing counts up" do
    store = Storex.Test.start_store!(MyApp.Store.Counter)

    assert {:ok, result} = Storex.Test.commit(store, "increase")

    assert result.state == %{counter: 1}
    assert result.diff == [%{a: "u", p: [:counter], t: 1}]
  end
end
```

`result.diff` is the reason this exists. The diff is the contract with the
frontend — it is what actually goes over the wire — and it is the part a store
author cannot otherwise get at without driving a browser.

## The API

```elixir
Storex.Test.start_store(Counter, params: %{...})  # {:ok, handle} | {:error, reason}
Storex.Test.start_store!(Counter)
Storex.Test.state(handle)
Storex.Test.commit(handle, "set", [3])            # {:ok, %{state:, diff:, message:}}
Storex.Test.commit!(handle, "set", [3])
Storex.Test.broadcast(handle, "reload", [], key: "user_id")
Storex.Test.stop(handle)
```

`commit/3` returns a plain map rather than a struct, so a test can match the part
it cares about and ignore the rest. `{:error, reason}` is whatever the client
would have received as an error frame: a mutation returning `{:error, reason}`, a
name no clause matches, or an unsupported return value. `start_store/2` returns
`{:error, reason}` when the store's `init/2` does, so refusing to start is
testable; the bang variants raise instead, for the cases a test does not mean to
assert on.

`Storex.Test` lives in `lib/` so it ships to users, the way `Plug.Test` does.
`mix.exs` already packages `lib`.

## broadcast/4 closes a real gap

`Storex.mutate/3` fans out over `:pg` and sends the mutation to each session's
*socket* process, which is what normally turns it into a call on the store. There
is no socket in a unit test — this repo writes a 30-line `FakeWebsocketServer` in
`storex_test.exs` to work around exactly that. `broadcast/4` waits for the
message and applies it, so the `:pg` path, the registry match and the `:key`
filter are covered by one call. `{:error, :timeout}` is the assertion for a store
the fan-out should *not* have reached.

## stop/1 waits

`Storex.Supervisor.remove_store/2` is a cast, so asserting on what `terminate/3`
did on the next line is a race. `stop/1` monitors the store and waits for it to go
down.

## Cleanup is not a convenience

`start_store/2` registers an `ExUnit` `on_exit` that stops the store.
`Storex.Registry` monitors the store process, not the session, so without this
every test that starts a store leaks one for the rest of the run. ExUnit is
reached through `apply/3` behind `Code.ensure_loaded?/1`, so the module carries no
compile-time reference to a test-only dependency and
`mix compile --warnings-as-errors` stays clean in dev and prod.

The calling process is registered as the session, which is what lets `broadcast/4`
observe the fan-out.

## Deliberately not done

- **The existing suite was not migrated onto it.** `supervisor_test.exs` and
  `store_test.exs` test `Storex.Supervisor` and `Storex.Store` on purpose, which
  is the layer below this. Rewriting them through the helper would lose that.
- **No SSR helper.** `Storex.HTTP.init_store/2` is already a plain function
  returning a plain map, and `http_test.exs` calls it directly without ceremony.
- **No assertion macros** (`assert_diff`, `assert_state`). `commit/3` hands back
  plain data and `assert` on it reads fine; a macro layer would be more to learn,
  not less.

## Tests

`test/storex/test_test.exs`, 28 tests covering every function, both bang variants,
the error paths, the `:key` filter, `terminate/3` through `stop/1`, and the
automatic cleanup. 143 non-browser tests pass on three seeds;
`mix compile --warnings-as-errors` and `mix format --check-formatted` are clean.
The 21 browser tests still need chromedriver and did not run here.
